### PR TITLE
Fix docker compose file

### DIFF
--- a/apps/playground-web/docker-compose.yml
+++ b/apps/playground-web/docker-compose.yml
@@ -1,26 +1,38 @@
 services:
+  dicedbadmin:
+    image: dicedb/dicedb:latest
+    ports:
+      - '7379:7379'
+
   dicedb:
     image: dicedb/dicedb:latest
     ports:
-      - "7379:7379"
+      - '7380:7379'
 
   backend:
     build:
       context: .
-      dockerfile: PlaygroundMonoDockerfile 
+      dockerfile: PlaygroundMonoDockerfile
     ports:
-      - "8080:8080"
+      - '8080:8080'
     depends_on:
+      - dicedbadmin
       - dicedb
     environment:
+      - DICEDB_ADMIN_ADDR=dicedbadmin:7379
+      - DICEDB_ADMIN_USERNAME=${DICEDB_ADMIN_USERNAME}
+      - DICEDB_ADMIN_PASSWORD=${DICEDB_ADMIN_PASSWORD}
       - DICEDB_ADDR=dicedb:7379
+      - DICEDB_USERNAME=${DICEDB_USERNAME}
+      - DICEDB_PASSWORD=${DICEDB_PASSWORD}
 
   frontend:
     build:
       context: ../../
-      dockerfile: ./apps/playground-web/Dockerfile  # Specify the correct Dockerfile for the frontend
+      dockerfile: ./apps/playground-web/Dockerfile # Specify the correct Dockerfile for the frontend
     ports:
-      - "3000:3000"
+      - '3000:3000'
     depends_on:
+      - dicedbadmin
       - dicedb
       - backend


### PR DESCRIPTION
- Output:
```
[+] Running 4/0
 ✔ Container playground-web-dicedbadmin-1  Created                                                                                       0.0s
 ✔ Container playground-web-dicedb-1       Created                                                                                       0.0s
 ✔ Container playground-web-backend-1      Created                                                                                       0.0s
 ✔ Container playground-web-frontend-1     Created                                                                                       0.0s
Attaching to backend-1, dicedb-1, dicedbadmin-1, frontend-1
dicedb-1       |
dicedb-1       | ██████╗ ██╗ ██████╗███████╗██████╗ ██████╗
dicedb-1       | ██╔══██╗██║██╔════╝██╔════╝██╔══██╗██╔══██╗
dicedb-1       | ██║  ██║██║██║     █████╗  ██║  ██║██████╔╝
dicedb-1       | ██║  ██║██║██║     ██╔══╝  ██║  ██║██╔══██╗
dicedb-1       | ██████╔╝██║╚██████╗███████╗██████╔╝██████╔╝
dicedb-1       | ╚═════╝ ╚═╝ ╚═════╝╚══════╝╚═════╝ ╚═════╝
dicedb-1       |
dicedbadmin-1  |
dicedbadmin-1  | ██████╗ ██╗ ██████╗███████╗██████╗ ██████╗
dicedbadmin-1  | ██╔══██╗██║██╔════╝██╔════╝██╔══██╗██╔══██╗
dicedbadmin-1  | ██║  ██║██║██║     █████╗  ██║  ██║██████╔╝
dicedbadmin-1  | ██║  ██║██║██║     ██╔══╝  ██║  ██║██╔══██╗
dicedbadmin-1  | ██████╔╝██║╚██████╗███████╗██████╔╝██████╔╝
dicedbadmin-1  | ╚═════╝ ╚═╝ ╚═════╝╚══════╝╚═════╝ ╚═════╝
dicedbadmin-1  |
dicedb-1       | 2024-10-26T17:06:13Z INF starting DiceDB version=0.0.5
dicedbadmin-1  | 2024-10-26T17:06:13Z INF starting DiceDB version=0.0.5
dicedbadmin-1  | 2024-10-26T17:06:13Z INF running with port=7379
dicedb-1       | 2024-10-26T17:06:13Z INF running with port=7379
dicedb-1       | 2024-10-26T17:06:13Z INF running with enable-watch=false
dicedbadmin-1  | 2024-10-26T17:06:13Z INF running with enable-watch=false
dicedb-1       | 2024-10-26T17:06:13Z INF running with mode=single-threaded
dicedb-1       | 2024-10-26T17:06:13Z WRN running without authentication, consider setting a password
dicedbadmin-1  | 2024-10-26T17:06:13Z INF running with mode=single-threaded
dicedbadmin-1  | 2024-10-26T17:06:13Z WRN running without authentication, consider setting a password
backend-1      | 2024/10/26 17:06:13 INFO starting HTTP server at addr=:8080
frontend-1     |
frontend-1     | > @dicedb/playground-web@0.1.0 start /prod/playground-web
frontend-1     | > pnpx serve out
frontend-1     |
frontend-1     |  INFO  Accepting connections at http://localhost:3000
```