### PR TITLE
show `dice >` after entering blocklisted command

### DIFF
--- a/apps/playground-web/components/Shell/__tests__/index.test.tsx
+++ b/apps/playground-web/components/Shell/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { getAllByTestId, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Shell from '../Shell';
 
@@ -55,13 +55,15 @@ describe('Shell Component', () => {
   });
 
   it('should throw error when user types blocklisted command', async () => {
-    const { cliInputElement, user, getByTestId } = setupTest();
+    const { cliInputElement, user, getAllByTestId } = setupTest();
 
     await user.type(cliInputElement, 'EXEC{enter}');
-    const terminalOutputElement = getByTestId('terminal-output');
-    expect(terminalOutputElement).toHaveTextContent(
-      "(error) ERR unknown command 'EXEC'",
+    const terminalOutputElements = getAllByTestId('terminal-output');
+
+    const errorElement = terminalOutputElements.find((element) =>
+      element.textContent?.includes("(error) ERR unknown command 'EXEC'"),
     );
+    expect(errorElement).toBeDefined();
   });
 
   it('should navigate through command history', async () => {

--- a/apps/playground-web/components/Shell/hooks/useShell.tsx
+++ b/apps/playground-web/components/Shell/hooks/useShell.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect, useRef, KeyboardEvent, ChangeEvent } from 'react';
 
 // utils
-import { handleCommand } from '@/shared/utils/shellUtils';
+import { handleCommand, handleInvalidCommand } from '@/shared/utils/shellUtils';
 import blocklistedCommands from '@/shared/utils/blocklist';
 
 export const useShell = (
@@ -29,10 +29,7 @@ export const useShell = (
     }
 
     if (blocklistedCommands.includes(commandName)) {
-      setOutput((prevOutput) => [
-        ...prevOutput,
-        `(error) ERR unknown command '${commandName}'`,
-      ]);
+      handleInvalidCommand({ command, setOutput });
     } else {
       handleCommand({ command, setOutput, onCommandExecuted }); // Execute if not blocklisted
     }

--- a/apps/playground-web/components/Shell/hooks/useShell.tsx
+++ b/apps/playground-web/components/Shell/hooks/useShell.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect, useRef, KeyboardEvent, ChangeEvent } from 'react';
 
 // utils
-import { handleCommand, handleInvalidCommand } from '@/shared/utils/shellUtils';
+import { handleCommand, handleBlockedCommand } from '@/shared/utils/shellUtils';
 import blocklistedCommands from '@/shared/utils/blocklist';
 
 export const useShell = (
@@ -29,7 +29,7 @@ export const useShell = (
     }
 
     if (blocklistedCommands.includes(commandName)) {
-      handleInvalidCommand({ command, setOutput });
+      handleBlockedCommand({ command, setOutput });
     } else {
       handleCommand({ command, setOutput, onCommandExecuted }); // Execute if not blocklisted
     }

--- a/apps/playground-web/shared/utils/shellUtils.ts
+++ b/apps/playground-web/shared/utils/shellUtils.ts
@@ -1,8 +1,20 @@
 // src/shared/utils/shellUtils.ts
 
 import { executeShellCommandOnServer } from '@/lib/api';
-import { CommandHandler } from '@/types';
+import { CommandHandler, InvalidCommandHandler } from '@/types';
 import { handleResult } from '@/shared/utils/commonUtils';
+
+export const handleInvalidCommand = async ({
+  command, 
+  setOutput
+}: InvalidCommandHandler) => {
+  const newOutput = `dice > ${command}`;
+  setOutput((prevOutput: any) => [
+    ...prevOutput,
+    newOutput,
+    `(error) ERR unknown command '${command}'`,
+  ]);
+}
 
 export const handleCommand = async ({
   command,

--- a/apps/playground-web/shared/utils/shellUtils.ts
+++ b/apps/playground-web/shared/utils/shellUtils.ts
@@ -1,13 +1,13 @@
 // src/shared/utils/shellUtils.ts
 
 import { executeShellCommandOnServer } from '@/lib/api';
-import { CommandHandler, InvalidCommandHandler } from '@/types';
+import { CommandHandler, BlockedCommandHandler } from '@/types';
 import { handleResult } from '@/shared/utils/commonUtils';
 
 export const handleBlockedCommand = async ({
   command,
   setOutput,
-}: InvalidCommandHandler) => {
+}: BlockedCommandHandler) => {
   const newOutput = `dice > ${command}`;
   setOutput((prevOutput: any) => [
     ...prevOutput,

--- a/apps/playground-web/shared/utils/shellUtils.ts
+++ b/apps/playground-web/shared/utils/shellUtils.ts
@@ -4,9 +4,9 @@ import { executeShellCommandOnServer } from '@/lib/api';
 import { CommandHandler, InvalidCommandHandler } from '@/types';
 import { handleResult } from '@/shared/utils/commonUtils';
 
-export const handleInvalidCommand = async ({
-  command, 
-  setOutput
+export const handleBlockedCommand = async ({
+  command,
+  setOutput,
 }: InvalidCommandHandler) => {
   const newOutput = `dice > ${command}`;
   setOutput((prevOutput: any) => [
@@ -14,7 +14,7 @@ export const handleInvalidCommand = async ({
     newOutput,
     `(error) ERR unknown command '${command}'`,
   ]);
-}
+};
 
 export const handleCommand = async ({
   command,

--- a/apps/playground-web/types/index.d.ts
+++ b/apps/playground-web/types/index.d.ts
@@ -5,3 +5,8 @@ export interface CommandHandler {
   setOutput: React.Dispatch<React.SetStateAction<string[]>>;
   onCommandExecuted: (commandsLeft: number, cleanupTimeLeft: number) => void;
 }
+
+export interface InvalidCommandHandler {
+  command: string;
+  setOutput: React.Dispatch<React.SetStateAction<string[]>>;
+}

--- a/apps/playground-web/types/index.d.ts
+++ b/apps/playground-web/types/index.d.ts
@@ -6,7 +6,7 @@ export interface CommandHandler {
   onCommandExecuted: (commandsLeft: number, cleanupTimeLeft: number) => void;
 }
 
-export interface InvalidCommandHandler {
+export interface BlockedCommandHandler {
   command: string;
   setOutput: React.Dispatch<React.SetStateAction<string[]>>;
 }


### PR DESCRIPTION
Added a new function named ``handleBlockedCommand`` that handles the issue mentioned in #84 

Fixes: #84 